### PR TITLE
Fix N+1 selects problem for users

### DIFF
--- a/src/main/kotlin/hu/kirdev/schpincer/model/UserEntity.kt
+++ b/src/main/kotlin/hu/kirdev/schpincer/model/UserEntity.kt
@@ -1,6 +1,7 @@
 package hu.kirdev.schpincer.model
 
 import java.io.Serializable
+import org.hibernate.annotations.BatchSize
 import jakarta.persistence.*
 
 @Entity
@@ -28,6 +29,7 @@ data class UserEntity(
 
         @Column
         @ElementCollection(fetch = FetchType.EAGER)
+        @BatchSize(size = 1000)
         var permissions: Set<String> = mutableSetOf(),
 
         @Column(nullable = false)


### PR DESCRIPTION
Even though FetchType.EAGER is set, the ORM doesn't seem to want to use a JOIN and instead loads permissions one-by-one. This should work around it.

A better solution would be to write a custom SQL query using a FETCH, but I can't be bothered to figure that out.

This should significantly improve loading times for the /admin and /configure/{circleId} endpoints