### PR TITLE
Add `/order/{providerId}` endpoint

### DIFF
--- a/src/main/kotlin/hu/kirdev/schpincer/config/SecurityConfig.kt
+++ b/src/main/kotlin/hu/kirdev/schpincer/config/SecurityConfig.kt
@@ -51,6 +51,7 @@ open class SecurityConfig {
             ).permitAll()
             auth.requestMatchers("/loggedin", "/login").permitAll()
             auth.requestMatchers("/api/**").permitAll()
+            auth.requestMatchers("/order/**").hasRole(Role.USER.name)
             auth.requestMatchers("/profile", "/profile/**", "/stats").hasRole(Role.USER.name)
             auth.requestMatchers("/configure/**").hasAnyRole(Role.LEADER.name, Role.ADMIN.name)
             auth.requestMatchers("/admin", "/admin/**").hasRole(Role.ADMIN.name)

--- a/src/main/kotlin/hu/kirdev/schpincer/web/FalatozoController.kt
+++ b/src/main/kotlin/hu/kirdev/schpincer/web/FalatozoController.kt
@@ -2,6 +2,7 @@ package hu.kirdev.schpincer.web
 
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.servlet.HandlerMapping
 import jakarta.servlet.http.HttpServletRequest
 
@@ -12,6 +13,11 @@ open class FalatozoController {
     fun providerRedirects(request: HttpServletRequest): String {
         val providerName = request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE) as String
         return "redirect:/p$providerName"
+    }
+
+    @GetMapping("/order/{providerId}")
+    fun orderProvider(@PathVariable providerId: String): String {
+        return "redirect:/provider/$providerId"
     }
 
 }


### PR DESCRIPTION
This change adds an endpoint that prompts the user to log in if not logged in, then redirects to the given provider's page.

The previous flow for placing an order:
1. Follow a link to `/provider/{}`
2. Click an item
3. Get told to log in
4. Close the popup, find the log-in button
5. Log in, get redirected to the home page
6. Remember what you wanted to order
7. Find the page of the provider
8. Find what you wanted to order
9. Don't order because the item went out of stock while you went on an adventure

After this change:
1. Follow a link to `/order/{}`
2. Log in
3. Find item
4. Order